### PR TITLE
Exit when stdin closes

### DIFF
--- a/bin/main.js
+++ b/bin/main.js
@@ -138,6 +138,9 @@ module.exports = function main(source, outDir, args) {
     }
 
     if (args.watch) {
+        process.stdin.on('end', () => process.exit(0))
+        process.stdin.resume()
+
         if (options.initialCopy) {
             log()
             log(`Copy: ${source} --> ${outDir}`)


### PR DESCRIPTION
This is useful for long running processes that are started by other tools like web frameworks.

These two lines were taken from the [postcss-cli](https://github.com/postcss/postcss-cli/blob/4be419d4dab07b8982b4bdc04456c02880dbf667/index.js#L55..L56).
