### PR TITLE
Return a report object containing details about the copy operation

### DIFF
--- a/lib/copy-sync.js
+++ b/lib/copy-sync.js
@@ -48,20 +48,29 @@ module.exports = function copySync(source, outputDir, options) {
     options = normalizeOptions(source, outputDir, options) //eslint-disable-line no-param-reassign
 
     // Clean
+    let cleaned = []
     if (options.clean) {
         const output = options.toDestination(options.source)
         if (output !== options.source) {
-            applyActionSync(output, options, targetPath => {
+            cleaned = applyActionSync(output, options, targetPath => {
                 removeFileSync(targetPath)
             })
         }
     }
 
     // Copy
-    applyActionSync(options.source, options, sourcePath => {
+    const copied = applyActionSync(options.source, options, sourcePath => {
         const outputPath = options.toDestination(sourcePath)
         if (outputPath !== sourcePath) {
             copyFileSync(sourcePath, outputPath, options)
         }
     })
+
+    const report = {
+        cleaned,
+        copied: copied.filter(r => r), // clean holes
+        options,
+    }
+
+    return report
 }

--- a/lib/copy.js
+++ b/lib/copy.js
@@ -10,7 +10,6 @@
 //------------------------------------------------------------------------------
 
 const assert = require("assert")
-const co = require("co")
 const normalizeOptions = require("./utils/normalize-options")
 const applyAction = require("./utils/apply-action")
 const copyFile = require("./utils/copy-file")
@@ -36,7 +35,7 @@ const removeFile = require("./utils/remove-file")
  * @param {function(Error):void} [callback] The callback function which will go fulfilled after done.
  * @returns {Promise<void>} The promise which will go fulfilled after done.
  */
-module.exports = function copy(source, outputDir, options, callback) {
+module.exports = async function copy(source, outputDir, options, callback) {
     /*eslint-disable no-param-reassign */
     if (typeof options === "function") {
         callback = options
@@ -44,50 +43,52 @@ module.exports = function copy(source, outputDir, options, callback) {
     }
     /*eslint-enable no-param-reassign */
 
-    const promise = co(function*() {
-        assert(typeof source === "string", "'source' should be a string.")
-        assert(source.trim().length >= 1, "'source' should not be empty.")
-        assert(typeof outputDir === "string", "'outputDir' should be a string.")
-        assert(outputDir.trim().length >= 1, "'outputDir' should not be empty.")
-        if (options != null) {
-            assert(
-                typeof options === "object",
-                "'options' should be an object."
-            )
-        }
-        if (callback != null) {
-            assert(
-                typeof callback === "function",
-                "'callback' should be a function."
-            )
-        }
-
-        //eslint-disable-next-line no-param-reassign
-        options = normalizeOptions(source, outputDir, options)
-
-        // Clean
-        if (options.clean) {
-            const output = options.toDestination(options.source)
-            if (output !== options.source) {
-                yield applyAction(output, options, targetPath =>
-                    removeFile(targetPath)
-                )
-            }
-        }
-
-        // Copy
-        yield applyAction(options.source, options, sourcePath => {
-            const outputPath = options.toDestination(sourcePath)
-            if (outputPath !== sourcePath) {
-                return copyFile(sourcePath, outputPath, options)
-            }
-            return Promise.resolve()
-        })
-    })
-
+    assert(typeof source === "string", "'source' should be a string.")
+    assert(source.trim().length >= 1, "'source' should not be empty.")
+    assert(typeof outputDir === "string", "'outputDir' should be a string.")
+    assert(outputDir.trim().length >= 1, "'outputDir' should not be empty.")
+    if (options != null) {
+        assert(typeof options === "object", "'options' should be an object.")
+    }
     if (callback != null) {
-        promise.then(() => callback(null), callback)
+        assert(
+            typeof callback === "function",
+            "'callback' should be a function."
+        )
     }
 
-    return promise
+    //eslint-disable-next-line no-param-reassign
+    options = normalizeOptions(source, outputDir, options)
+
+    // Clean
+    let cleaned = []
+    if (options.clean) {
+        const output = options.toDestination(options.source)
+        if (output !== options.source) {
+            cleaned = await applyAction(output, options, targetPath =>
+                removeFile(targetPath)
+            )
+        }
+    }
+
+    // Copy
+    const copied = await applyAction(options.source, options, sourcePath => {
+        const outputPath = options.toDestination(sourcePath)
+        if (outputPath !== sourcePath) {
+            return copyFile(sourcePath, outputPath, options)
+        }
+        return Promise.resolve()
+    })
+
+    const report = {
+        cleaned,
+        copied: copied.filter(r => r), // clean holes,
+        options,
+    }
+
+    if (callback != null) {
+        callback(null, report)
+    }
+
+    return report
 }

--- a/lib/utils/apply-action-sync.js
+++ b/lib/utils/apply-action-sync.js
@@ -34,7 +34,11 @@ module.exports = function applyActionSync(pattern, options, action) {
         follow: Boolean(options.dereference),
         ignore: options.ignore,
     }
+    const results = []
     for (const sourcePath of glob.sync(pattern, globOptions)) {
-        action(sourcePath)
+        const result = action(sourcePath)
+        results.push(result)
     }
+
+    return results
 }

--- a/lib/utils/copy-file.js
+++ b/lib/utils/copy-file.js
@@ -6,7 +6,6 @@
 "use strict"
 
 const path = require("path")
-const co = require("co")
 const fs = require("fs-extra")
 
 /**
@@ -77,19 +76,19 @@ function copyFileContent(source, output, transforms) {
  * @param {function[]} options.transform - Factory functions for transform streams.
  * @param {boolean} options.preserve - The flag to copy attributes.
  * @param {boolean} options.update - The flag to disallow overwriting.
- * @returns {Promise<void>} The promise which will go fulfilled after done.
+ * @returns {Promise<object>} The promise which will go fulfilled after done.
  * @private
  */
-module.exports = co.wrap(function* copyFile(source, output, options) {
-    const stat = yield fs.stat(source)
+module.exports = async function copyFile(source, output, options) {
+    const stat = await fs.stat(source)
 
     if (options.update) {
         try {
-            const dstStat = yield fs.stat(output)
+            const dstStat = await fs.stat(output)
             if (dstStat.mtime.getTime() > stat.mtime.getTime()) {
                 // Don't overwrite because the file on destination is newer than
                 // the source file.
-                return
+                return { source, output, skipped: true }
             }
         } catch (dstStatError) {
             if (dstStatError.code !== "ENOENT") {
@@ -99,15 +98,17 @@ module.exports = co.wrap(function* copyFile(source, output, options) {
     }
 
     if (stat.isDirectory()) {
-        yield fs.ensureDir(output)
+        await fs.ensureDir(output)
     } else {
-        yield fs.ensureDir(path.dirname(output))
-        yield copyFileContent(source, output, options.transform)
+        await fs.ensureDir(path.dirname(output))
+        await copyFileContent(source, output, options.transform)
     }
-    yield fs.chmod(output, stat.mode)
+    await fs.chmod(output, stat.mode)
 
     if (options.preserve) {
-        yield fs.chown(output, stat.uid, stat.gid)
-        yield fs.utimes(output, stat.atime, stat.mtime)
+        await fs.chown(output, stat.uid, stat.gid)
+        await fs.utimes(output, stat.atime, stat.mtime)
     }
-})
+
+    return { source, output, skipped: false }
+}

--- a/lib/utils/remove-file.js
+++ b/lib/utils/remove-file.js
@@ -10,7 +10,6 @@
 //------------------------------------------------------------------------------
 
 const path = require("path")
-const co = require("co")
 const fs = require("fs-extra")
 
 //------------------------------------------------------------------------------
@@ -24,13 +23,15 @@ const fs = require("fs-extra")
  * @returns {void}
  * @private
  */
-module.exports = co.wrap(function* removeFile(target) {
+module.exports = async function removeFile(target) {
+    let report = null
     try {
-        const stat = yield fs.stat(target)
+        const stat = await fs.stat(target)
         if (stat.isDirectory()) {
-            yield fs.rmdir(target)
+            await fs.rmdir(target)
         } else {
-            yield fs.unlink(target)
+            await fs.unlink(target)
+            report = target
         }
     } catch (err) {
         if (err.code !== "ENOENT") {
@@ -40,10 +41,12 @@ module.exports = co.wrap(function* removeFile(target) {
 
     // Remove the parent directory if possible.
     try {
-        yield fs.rmdir(path.dirname(target))
+        await fs.rmdir(path.dirname(target))
     } catch (err) {
         if (err.code !== "ENOTEMPTY") {
             throw err
         }
     }
-})
+
+    return report
+}

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -10,7 +10,6 @@
 //------------------------------------------------------------------------------
 
 const assert = require("assert")
-const co = require("co")
 const normalizeOptions = require("./utils/normalize-options")
 const applyAction = require("./utils/apply-action")
 const removeFile = require("./utils/remove-file")
@@ -49,13 +48,13 @@ module.exports = function watch(source, outputDir, options) {
 
     const watcher = new Watcher(options)
 
-    co(function*() {
+    async function start() {
         // Clean
         try {
             if (options.clean) {
                 const output = options.toDestination(options.source)
                 if (output !== options.source) {
-                    yield applyAction(output, options, targetPath =>
+                    await applyAction(output, options, targetPath =>
                         removeFile(targetPath)
                     )
                 }
@@ -66,7 +65,9 @@ module.exports = function watch(source, outputDir, options) {
         }
 
         watcher.open()
-    })
+    }
+
+    start()
 
     return watcher
 }

--- a/test/util/util.js
+++ b/test/util/util.js
@@ -12,7 +12,6 @@
 const assert = require("assert")
 const exec = require("child_process").exec
 const dirname = require("path").dirname
-const co = require("co")
 const fs = require("fs-extra")
 const execSync = require("shelljs").exec
 
@@ -37,13 +36,13 @@ const delay = (module.exports.delay = function delay(ms) {
  * @param {string} contentText - A text to write.
  * @returns {Promise<void>} The promise which will go fulfilled after done.
  */
-const writeFile = (module.exports.writeFile = co.wrap(function* writeFile(
+const writeFile = (module.exports.writeFile = async function writeFile(
     path,
     contentText
 ) {
-    yield fs.ensureDir(dirname(path))
-    yield fs.writeFile(path, contentText)
-}))
+    await fs.ensureDir(dirname(path))
+    await fs.writeFile(path, contentText)
+})
 
 /**
  * Removes a specific file.
@@ -97,12 +96,12 @@ module.exports.teardownTestDir = function teardownTestDir(testRootPath) {
  * @param {object} dataset - Test data to write.
  * @returns {Promise<void>} The promise which will go fulfilled after done.
  */
-module.exports.verifyTestDir = co.wrap(function* verifyTestDir(dataset) {
+module.exports.verifyTestDir = async function verifyTestDir(dataset) {
     for (const path of Object.keys(dataset)) {
-        const content = yield readFile(path)
+        const content = await readFile(path)
         assert.strictEqual(content, dataset[path])
     }
-})
+}
 
 /**
  * Execute cpx command.


### PR DESCRIPTION
This lets consumers of the API introspect what cpx is doing, present information, and generally write tests against its behavior.