### PR TITLE
fix #53 - Overwrite readonly files

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ Options:
     -c, --command <command>   A command text to transform each file.
     -C, --clean               Clean files that matches <source> like pattern in
                               <dest> directory before the first copying.
-    -i  --ignore              A comma separated list of gitignore style ignore
+    -f, --force               Force the file to be copied, even if the
+                              destination is readonly.   
+    -i, --ignore              A comma separated list of gitignore style ignore
                               patterns.
     -L, --dereference         Follow symbolic links when copying from them.
     -h, --help                Print usage information.
@@ -109,6 +111,7 @@ cpx.copy(source, dest, callback)
   - **options.dereference** `{boolean}` -- The flag to follow symbolic links when copying from them. Default: `false`.
   - **options.includeEmptyDirs** `{boolean}` -- The flag to copy empty directories which is matched with the glob. Default: `false`.
   - **options.initialCopy** `{boolean}` -- The flag to not copy at the initial time of watch. This is for `cpx.watch()`. Default: `true`.
+  - **options.force** `{boolean}` -- The flag to copy file to the destination, even if it is readonly.
   - **options.preserve** `{boolean}` -- The flag to copy uid, gid, atime, and mtime of files. Default: `false`.
   - **options.transform** `{((filepath: string) => stream.Transform)[]}` -- Functions that creates a `stream.Transform` object to transform each copying file.
   - **options.update** `{boolean}` -- The flag to not overwrite files on destination if the source file is older. Default: `false`.

--- a/bin/help.js
+++ b/bin/help.js
@@ -28,7 +28,9 @@ Options:
     -c, --command <command>   A command text to transform each file.
     -C, --clean               Clean files that matches <source> like pattern in
                               <dest> directory before the first copying.
-    -i  --ignore              A comma separated list of gitignore style ignore
+    -f, --force               Force the file to be copied, even if the
+                              destination is readonly.
+    -i, --ignore              A comma separated list of gitignore style ignore
                               patterns.
     -L, --dereference         Follow symbolic links when copying from them.
     -h, --help                Print usage information.

--- a/bin/index.js
+++ b/bin/index.js
@@ -22,6 +22,7 @@ const args = subarg(process.argv.slice(2), {
     alias: {
         c: "command",
         C: "clean",
+        f: "force",
         h: "help",
         includeEmptyDirs: "include-empty-dirs",
         i: "ignore",
@@ -37,6 +38,7 @@ const args = subarg(process.argv.slice(2), {
         "clean",
         "dereference",
         "help",
+        "force",
         "include-empty-dirs",
         "initial",
         "preserve",

--- a/bin/main.js
+++ b/bin/main.js
@@ -115,6 +115,7 @@ module.exports = function main(source, outDir, args) {
         dereference: args.dereference,
         includeEmptyDirs: args.includeEmptyDirs,
         initialCopy: args.initial,
+        force: args.force,
         preserve: args.preserve,
         update: args.update,
         ignore: args.ignore && args.ignore.split(","),

--- a/lib/copy-sync.js
+++ b/lib/copy-sync.js
@@ -28,6 +28,7 @@ const removeFileSync = require("./utils/remove-file-sync")
  * @param {boolean} [options.dereference=false] The flag to dereference symbolic links.
  * @param {boolean} [options.includeEmptyDirs=false] The flag to copy empty directories.
  * @param {boolean} [options.initialCopy=true] The flag to copy files at the first time.
+ * @param {boolean} [options.force=false] The flag to copy file to the destination, even if it is readonly.
  * @param {boolean} [options.preserve=false] The flag to copy file attributes such as timestamps, users, and groups.
  * @param {boolean} [options.update=false] The flag to not overwrite newer files.
  * @param {string|Array.<string>} [options.ignore] - gitignore string or array of gitignore strings

--- a/lib/copy.js
+++ b/lib/copy.js
@@ -28,6 +28,7 @@ const removeFile = require("./utils/remove-file")
  * @param {boolean} [options.dereference=false] The flag to dereference symbolic links.
  * @param {boolean} [options.includeEmptyDirs=false] The flag to copy empty directories.
  * @param {boolean} [options.initialCopy=true] The flag to copy files at the first time.
+ * @param {boolean} [options.force=false] The flag to copy file to the destination, even if it is readonly.
  * @param {boolean} [options.preserve=false] The flag to copy file attributes such as timestamps, users, and groups.
  * @param {(function(string):void)[]} [options.transform] The array of the factories of transform streams.
  * @param {boolean} [options.update=false] The flag to not overwrite newer files.

--- a/lib/utils/copy-file-sync.js
+++ b/lib/utils/copy-file-sync.js
@@ -47,6 +47,10 @@ module.exports = function copyFileSync(source, output, options) {
         fs.ensureDirSync(output)
     } else {
         fs.ensureDirSync(path.dirname(output))
+
+        if (!(stat.mode & 0o200) && options.force) {
+            await fs.chmod(output, stat.mode | 0o200);
+        }
         fs.copySync(source, output)
     }
     fs.chmodSync(output, stat.mode)

--- a/lib/utils/copy-file.js
+++ b/lib/utils/copy-file.js
@@ -101,6 +101,10 @@ module.exports = async function copyFile(source, output, options) {
         await fs.ensureDir(output)
     } else {
         await fs.ensureDir(path.dirname(output))
+
+        if (!(stat.mode & 0o200) && options.force) {
+            await fs.chmod(output, stat.mode | 0o200);
+        }
         await copyFileContent(source, output, options.transform)
     }
     await fs.chmod(output, stat.mode)

--- a/lib/utils/normalize-options.js
+++ b/lib/utils/normalize-options.js
@@ -42,11 +42,12 @@ function getBasePath(source) {
  * @param {boolean} [options.dereference=false] The flag to dereference symbolic links.
  * @param {boolean} [options.includeEmptyDirs=false] The flag to copy empty directories.
  * @param {boolean} [options.initialCopy=true] The flag to copy files at the first time.
+ * @param {boolean} [options.force=false] The flag force overwrite the destination, even if it is readonly.
  * @param {boolean} [options.preserve=false] The flag to copy file attributes such as timestamps, users, and groups.
  * @param {(function(string):stream.Transform)[]} [options.transform=null] The array of transform function's factories.
  * @param {boolean} [options.update=false] The flag to not overwrite newer files.
  * @param {string|Array.<string>} [options.ignore] - gitignore string or array of gitignore strings
- * @returns {{baseDir:string,clean:boolean,dereference:boolean,includeEmptyDirs:boolean,initialCopy:boolean,outputDir:string,preserve:boolean,source:string,transform:any[],toDestination:any,update:boolean,ignore:string|Array.<string>}} The normalized options.
+ * @returns {{baseDir:string,clean:boolean,dereference:boolean,includeEmptyDirs:boolean,initialCopy:boolean,outputDir:string,force:boolean,preserve:boolean,source:string,transform:any[],toDestination:any,update:boolean,ignore:string|Array.<string>}} The normalized options.
  * @private
  */
 module.exports = function normalizeOptions(source, outputDir, options) {
@@ -65,6 +66,7 @@ module.exports = function normalizeOptions(source, outputDir, options) {
         includeEmptyDirs: Boolean(options && options.includeEmptyDirs),
         initialCopy: (options && options.initialCopy) !== false,
         outputDir,
+        force: Boolean(options && options.force),
         preserve: Boolean(options && options.preserve),
         source: normalizedSource,
         toDestination,

--- a/lib/utils/watcher.js
+++ b/lib/utils/watcher.js
@@ -94,6 +94,7 @@ module.exports = class Watcher extends EventEmitter {
      * @param {boolean} options.includeEmptyDirs The flag to copy empty directories.
      * @param {boolean} options.initialCopy The flag to copy files at the first time.
      * @param {string} options.outputDir The path to the output directory.
+     * @param {boolean} options.force The flag to overwrite the destination, even if it is readonly.
      * @param {boolean} options.preserve The flag to copy file attributes such as timestamps, users, and groups.
      * @param {string} options.source The glob pattern of source files.
      * @param {(function(string):stream.Transform)[]} options.transform The array of transform function's factories.
@@ -111,6 +112,7 @@ module.exports = class Watcher extends EventEmitter {
         this.matcher = new Minimatch(options.source)
         this.ignore = ignore({ allowRelativePaths: true }).add(options.ignore)
         this.outputDir = options.outputDir
+        this.force = options.force
         this.preserve = options.preserve
         this.source = options.source
         this.toDestination = options.toDestination

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -28,6 +28,7 @@ const Watcher = require("./utils/watcher")
  * @param {boolean} [options.dereference=false] The flag to dereference symbolic links.
  * @param {boolean} [options.includeEmptyDirs=false] The flag to copy empty directories.
  * @param {boolean} [options.initialCopy=true] The flag to copy files at the first time.
+ * @param {boolean} [options.force=false] The flag to copy file to the destination, even if it is readonly..
  * @param {boolean} [options.preserve=false] The flag to copy file attributes such as timestamps, users, and groups.
  * @param {(function(string):void)[]} [options.transform] The array of the factories of transform streams.
  * @param {boolean} [options.update=false] The flag to not overwrite newer files.


### PR DESCRIPTION
As discussed. I've added a 'force'-flag to always overwrite the destination. If not set, the old behaviour (throws/logs an EACCESS-error) is still present.

Best regards,
--Martin