### PR TITLE
Set allowRelativePaths for apply acitons

### DIFF
--- a/lib/utils/apply-action-sync.js
+++ b/lib/utils/apply-action-sync.js
@@ -29,7 +29,7 @@ const ignore = require('ignore')
  * @private
  */
 module.exports = function applyActionSync (pattern, options, action) {
-  const ig = ignore().add(options.ignore ?? [])
+  const ig = ignore({ allowRelativePaths: true }).add(options.ignore ?? [])
   ig.add(options.ignore ?? [])
   const globOptions = {
     nodir: !options.includeEmptyDirs,

--- a/lib/utils/apply-action.js
+++ b/lib/utils/apply-action.js
@@ -30,7 +30,7 @@ const pMapPromise = import('p-map')
  * @private
  */
 module.exports = async function applyAction (pattern, options, action) {
-  const ig = ignore().add(options.ignore ?? [])
+  const ig = ignore({ allowRelativePaths: true }).add(options.ignore ?? [])
   ig.add(options.ignore ?? [])
   const globOptions = {
     nodir: !options.includeEmptyDirs,


### PR DESCRIPTION
This should improve support for relative copy paths. If I knew it was this easy I would have done it ages ago. 

Closes https://github.com/bcomnes/cpx2/issues/113